### PR TITLE
Fix for Kodi 18 + YTChannels

### DIFF
--- a/plugin.video.ytchannels/default.py
+++ b/plugin.video.ytchannels/default.py
@@ -635,9 +635,10 @@ elif mode[0]=='open_channel':
         thumb=game_list[i][2]
         desc=game_list[i][3]
         
-        uri='plugin://plugin.video.youtube/?action=play_video&videoid='+video_id
+        uri='plugin://plugin.video.youtube/play/?video_id='+video_id
         li = xbmcgui.ListItem('%s'%title, iconImage=thumb)
         li.setProperty('IsPlayable', 'true')
+        li.setInfo('video', { 'genre': 'YouTube' } )
 
         xbmcplugin.addDirectoryItem(handle=addon_handle, url=uri, listitem=li)#,isFolder=True)
 

--- a/plugin.video.ytchannels/default.py
+++ b/plugin.video.ytchannels/default.py
@@ -41,12 +41,7 @@ db=sqlite3.connect(new_db_path)
 my_addon = xbmcaddon.Addon()
 enable_playlists = my_addon.getSetting('enable_playlists')
 
-YOUTUBE_API_KEY = 'AIzaSyDIwXfF0WjgTUwuazYIc7SFDqr576b_xs4'
-
-top_channels_by_subscribe = 'http://vidstatsx.com/youtube-top-100-most-subscribed-channels'
-
-   
-
+YOUTUBE_API_KEY = my_addon.getSetting('youtube_api_key')
 
 categories_list=[['Autos and vehicles','http://vidstatsx.com/youtube-top-100-most-viewed-autos-vehicles'],['Comedy','http://vidstatsx.com/youtube-top-100-most-viewed-comedy'],
             ['Education','http://vidstatsx.com/youtube-top-100-most-viewed-education'],['Entertainment','http://vidstatsx.com/youtube-top-100-most-viewed-entertainment'],

--- a/plugin.video.ytchannels/resources/settings.xml
+++ b/plugin.video.ytchannels/resources/settings.xml
@@ -2,19 +2,22 @@
 <settings>
 	
     <category label="General">
-    <setting id="enable_playlists" type="bool" default="true" label="Enable playlists"/>
-    <setting id="show_lists" type="bool" default="true" label="Show charts and categories"/>
-    <setting id="show_adds" type="bool" default="true" label="Show 'Add folder/channel' options"/>
-    
-    <setting id="result_number" type="slider" default="20" range="10,5,100" option="int" label="Number of videos per page"/>
-    <setting id="result_number_channels" type="slider" default="20" range="10,5,100" option="int" label="Number of channel search results"/>
-    <setting id="result_number_channels_cat" type="slider" default="20" range="10,5,100" option="int" label="Number of channels in top and categories"/>
-    <setting label="Erase database" type="action" action="RunPlugin(plugin://plugin.video.ytchannels/?mode=erase_all)" enable="true" option="close"/>
+		<setting id="enable_playlists" type="bool" default="true" label="Enable playlists"/>
+		<setting id="show_lists" type="bool" default="true" label="Show charts and categories"/>
+		<setting id="show_adds" type="bool" default="true" label="Show 'Add folder/channel' options"/>
+		
+		<setting id="result_number" type="slider" default="20" range="10,5,100" option="int" label="Number of videos per page"/>
+		<setting id="result_number_channels" type="slider" default="20" range="10,5,100" option="int" label="Number of channel search results"/>
+		<setting id="result_number_channels_cat" type="slider" default="20" range="10,5,100" option="int" label="Number of channels in top and categories"/>
+		<setting label="Erase database" type="action" action="RunPlugin(plugin://plugin.video.ytchannels/?mode=erase_all)" enable="true" option="close"/>
     </category>
 
-    <category label="Import">
-    
-    <setting label="Import channels from old addon" type="action" action="RunPlugin(plugin://plugin.video.ytchannels/?mode=import)" enable="true" option="close"/>
+    <category label="Import">    
+		<setting label="Import channels from old addon" type="action" action="RunPlugin(plugin://plugin.video.ytchannels/?mode=import)" enable="true" option="close"/>
     </category>
+	
+	<category label="API Key">
+		<setting id="youtube_api_key" type="text" default="AIzaSyDIwXfF0WjgTUwuazYIc7SFDqr576b_xs4" label="YouTube API Key"/>
+	</category>
 </settings>
 


### PR DESCRIPTION
Yo,

Not sure if you're still using or maintaining this but it's broken under Kodi 18

Kodi 18's YouTube plugin only supports URLS in the more 'REST' format:
https://kodi.wiki/view/Add-on:YouTube#Integration_with_STRM_files
Also now the type has to be set in order to be directly playable, this needs some additional settings in the dictionary so I've bodged in genre
